### PR TITLE
upgrade karma-webpack to 2.0 to play nicely with webpack 2.0 when no entry points are available

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "karma-phantomjs-launcher": "^1.0.0",
     "karma-sinon": "^1.0.5",
     "karma-sourcemap-loader": "^0.3.7",
-    "karma-webpack": "^1.7.0",
+    "karma-webpack": "^2.0.3",
     "mocha": "^2.4.5",
     "node-sass": "^4.5.0",
     "npm-run-all": "^4.0.1",


### PR DESCRIPTION
In webpack 2.0 entry points are required. However, they aren't needed for testing. To make sure this will play nicely, this change will update karma webpack to 2.x so it's unnecessary to have entry points enabled.